### PR TITLE
Use shelljs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: node_js
 node_js:
   - 0.8
 before_script:
+  - npm update -g npm
   - npm install -g grunt-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 0.8
+  - 0.10
 before_script:
   - npm update -g npm
   - npm install -g grunt-cli

--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
     "gruntplugin",
     "chmod",
     "permissions"
-  ]
+  ],
+  "dependencies": {
+    "shelljs": "^0.5.3"
+  }
 }

--- a/tasks/chmod.js
+++ b/tasks/chmod.js
@@ -8,6 +8,8 @@
 
 'use strict';
 
+var shelljs = require('shelljs');
+
 module.exports = function(grunt) {
 
   // Please see the Grunt documentation for more information regarding task
@@ -54,7 +56,7 @@ module.exports = function(grunt) {
       
       // Write the destination file.
       try {
-        fs.chmodSync(path, mode);
+		shelljs.chmod(mode, path);	// was fs.chmodSync(path, mode);
       }
       catch (e) {
         logError('Failed to set `chmod` mode "' + mode + '" on dir/file: ' + path + '\n' + e);


### PR DESCRIPTION
This change simply puts shelljs in place of fs.chmodSync() without any guarantees of support for using symbolic expressions (ie go-w,a+rX). All existing tests pass.