### PR TITLE
Fully support single symbolic chmods (ie u+rwx)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
-  - 0.8
+  - 0.10
 before_script:
+  - npm update -g npm
   - npm install -g grunt-cli

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -74,7 +74,33 @@ module.exports = function(grunt) {
           mode: '444'
         },
         src: ['tmp/custom_options_dir/']
-      }
+      },
+      custom_options_file_symbolic_1: {
+        options: {
+          mode: 'a-rwx,u+r' // 400
+        },
+        src: ['tmp/custom_options_file_symbolic_1.js']
+      },
+      custom_options_file_symbolic_2: {
+        options: {
+          mode: 'a-rwx,u+rw' // 600
+        },
+        src: ['tmp/custom_options_file_symbolic_2.js']
+      },
+      custom_options_file_symbolic_3: {
+        options: {
+          mode: 'a-rwx,u+rwx' // 700
+        },
+        src: ['tmp/custom_options_file_symbolic_3.js']
+      },
+
+      custom_options_file_symbolic_4: {
+        options: {
+          mode: 'a-rwx,uo+r' // 404
+        },
+        src: ['tmp/custom_options_file_symbolic_4.js']
+      },
+
     },
 
     // Unit tests.
@@ -108,6 +134,10 @@ module.exports = function(grunt) {
   grunt.registerTask('test-setup', function() {
     grunt.file.mkdir('tmp/custom_options_dir');
     grunt.file.write('tmp/custom_options_file.js', '');
+    grunt.file.write('tmp/custom_options_file_symbolic_1.js', '');
+    grunt.file.write('tmp/custom_options_file_symbolic_2.js', '');
+    grunt.file.write('tmp/custom_options_file_symbolic_3.js', '');
+    grunt.file.write('tmp/custom_options_file_symbolic_4.js', '');
   });
   
   // Test emission listeners
@@ -160,7 +190,11 @@ module.exports = function(grunt) {
   });
   var goodConfigOptions = [
         'custom_options_file',
-        'custom_options_dir'
+        'custom_options_dir',
+		'custom_options_file_symbolic_1',
+		'custom_options_file_symbolic_2',
+		'custom_options_file_symbolic_3',
+		'custom_options_file_symbolic_4'
       ];
   goodConfigOptions.forEach(function(e, i) {
     grunt.registerTask(

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,6 +8,8 @@
 
 'use strict';
 
+var fs = require('fs');
+
 module.exports = function(grunt) {
 
   // Project configuration.
@@ -77,26 +79,26 @@ module.exports = function(grunt) {
       },
       custom_options_file_symbolic_1: {
         options: {
-          mode: 'a-rwx,u+r' // 400
+          mode: 'u+r' // 400
         },
         src: ['tmp/custom_options_file_symbolic_1.js']
       },
       custom_options_file_symbolic_2: {
         options: {
-          mode: 'a-rwx,u+rw' // 600
+          mode: 'u+rw' // 600
         },
         src: ['tmp/custom_options_file_symbolic_2.js']
       },
       custom_options_file_symbolic_3: {
         options: {
-          mode: 'a-rwx,u+rwx' // 700
+          mode: 'u+rwx' // 700
         },
         src: ['tmp/custom_options_file_symbolic_3.js']
       },
 
       custom_options_file_symbolic_4: {
         options: {
-          mode: 'a-rwx,uo+r' // 404
+          mode: 'uo+r' // 404
         },
         src: ['tmp/custom_options_file_symbolic_4.js']
       },
@@ -134,10 +136,18 @@ module.exports = function(grunt) {
   grunt.registerTask('test-setup', function() {
     grunt.file.mkdir('tmp/custom_options_dir');
     grunt.file.write('tmp/custom_options_file.js', '');
+
     grunt.file.write('tmp/custom_options_file_symbolic_1.js', '');
     grunt.file.write('tmp/custom_options_file_symbolic_2.js', '');
     grunt.file.write('tmp/custom_options_file_symbolic_3.js', '');
     grunt.file.write('tmp/custom_options_file_symbolic_4.js', '');
+
+	fs.chmodSync('tmp/custom_options_file_symbolic_1.js', '000');
+	fs.chmodSync('tmp/custom_options_file_symbolic_2.js', '000');
+	fs.chmodSync('tmp/custom_options_file_symbolic_3.js', '000');
+	fs.chmodSync('tmp/custom_options_file_symbolic_4.js', '000');
+	
+
   });
   
   // Test emission listeners

--- a/README.md
+++ b/README.md
@@ -44,11 +44,13 @@ grunt.initConfig({
 Type: `String`
 Default value: _none_ (required)
 
-A string value to specify the permissions' [numeric mode](http://ss64.com/bash/chmod.html) to set on the files and/or directories, e.g.:
+A string value to specify the permissions' [numeric mode](http://ss64.com/bash/chmod.html) to set on the files and/or directories. Alternatively, you may specify a change to be made to the permissions
+ using chmod's symbolic notation, e.g.:
  - `'755'`
  - `'644'`
  - `'400'`
-
+ - `'a+X'`
+ - `'ug+rw'`
 
 ### Usage Examples
 

--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
     "gruntplugin",
     "chmod",
     "permissions"
-  ]
+  ],
+  "dependencies": {
+    "shelljs": "^0.5.3"
+  }
 }

--- a/tasks/chmod.js
+++ b/tasks/chmod.js
@@ -8,6 +8,8 @@
 
 'use strict';
 
+var shelljs = require('shelljs');
+
 module.exports = function(grunt) {
 
   // Please see the Grunt documentation for more information regarding task
@@ -54,7 +56,7 @@ module.exports = function(grunt) {
       
       // Write the destination file.
       try {
-        fs.chmodSync(path, mode);
+		shelljs.chmod(mode, path);	// was fs.chmodSync(path, mode);
       }
       catch (e) {
         logError('Failed to set `chmod` mode "' + mode + '" on dir/file: ' + path + '\n' + e);

--- a/tasks/chmod.js
+++ b/tasks/chmod.js
@@ -56,7 +56,7 @@ module.exports = function(grunt) {
       
       // Write the destination file.
       try {
-		shelljs.chmod(mode, path);	// was fs.chmodSync(path, mode);
+        shelljs.chmod(mode, path);	// was fs.chmodSync(path, mode);
       }
       catch (e) {
         logError('Failed to set `chmod` mode "' + mode + '" on dir/file: ' + path + '\n' + e);

--- a/test/chmod_test.js
+++ b/test/chmod_test.js
@@ -91,6 +91,73 @@ exports.chmod = {
     test.strictEqual(actualPerms, expectedPerms, 'Permissions should match.');
 
     test.done();
-  }
+  },
 
+  custom_options_file_symbolic_1: function(test) {
+    test.expect(2);
+
+    var actual = grunt.file.readJSON('tmp/custom_options_file_symbolic_1.json');
+    var expected = grunt.file.readJSON('test/expected/custom_options_file_symbolic_1.json');
+    test.deepEqual(actual, expected, 'Task should pass and modify the file permissions of all files that match.');
+    
+    var rawMode = require('fs').statSync('tmp/custom_options_file.js').mode;
+    var numericMode = helpers.permsFromMode(rawMode);
+    
+    var actualPerms = '' + numericMode;
+    var expectedPerms = '400';
+    test.strictEqual(actualPerms, expectedPerms, 'Permissions should match.');
+
+    test.done();
+  },
+
+  custom_options_file_symbolic_2: function(test) {
+    test.expect(2);
+
+    var actual = grunt.file.readJSON('tmp/custom_options_file_symbolic_2.json');
+    var expected = grunt.file.readJSON('test/expected/custom_options_file_symbolic_2.json');
+    test.deepEqual(actual, expected, 'Task should pass and modify the file permissions of all files that match.');
+    
+    var rawMode = require('fs').statSync('tmp/custom_options_file.js').mode;
+    var numericMode = helpers.permsFromMode(rawMode);
+    
+    var actualPerms = '' + numericMode;
+    var expectedPerms = '600';
+    test.strictEqual(actualPerms, expectedPerms, 'Permissions should match.');
+
+    test.done();
+  },
+
+  custom_options_file_symbolic_3: function(test) {
+    test.expect(2);
+
+    var actual = grunt.file.readJSON('tmp/custom_options_file_symbolic_3.json');
+    var expected = grunt.file.readJSON('test/expected/custom_options_file_symbolic_3.json');
+    test.deepEqual(actual, expected, 'Task should pass and modify the file permissions of all files that match.');
+    
+    var rawMode = require('fs').statSync('tmp/custom_options_file.js').mode;
+    var numericMode = helpers.permsFromMode(rawMode);
+    
+    var actualPerms = '' + numericMode;
+    var expectedPerms = '700';
+    test.strictEqual(actualPerms, expectedPerms, 'Permissions should match.');
+
+    test.done();
+  },
+
+  custom_options_file_symbolic_4: function(test) {
+    test.expect(2);
+
+    var actual = grunt.file.readJSON('tmp/custom_options_file_symbolic_4.json');
+    var expected = grunt.file.readJSON('test/expected/custom_options_file_symbolic_4.json');
+    test.deepEqual(actual, expected, 'Task should pass and modify the file permissions of all files that match.');
+    
+    var rawMode = require('fs').statSync('tmp/custom_options_file.js').mode;
+    var numericMode = helpers.permsFromMode(rawMode);
+    
+    var actualPerms = '' + numericMode;
+    var expectedPerms = '404';
+    test.strictEqual(actualPerms, expectedPerms, 'Permissions should match.');
+
+    test.done();
+  }  
 };

--- a/test/chmod_test.js
+++ b/test/chmod_test.js
@@ -100,7 +100,7 @@ exports.chmod = {
     var expected = grunt.file.readJSON('test/expected/custom_options_file_symbolic_1.json');
     test.deepEqual(actual, expected, 'Task should pass and modify the file permissions of all files that match.');
     
-    var rawMode = require('fs').statSync('tmp/custom_options_file.js').mode;
+    var rawMode = require('fs').statSync('tmp/custom_options_file_symbolic_1.js').mode;
     var numericMode = helpers.permsFromMode(rawMode);
     
     var actualPerms = '' + numericMode;
@@ -117,7 +117,7 @@ exports.chmod = {
     var expected = grunt.file.readJSON('test/expected/custom_options_file_symbolic_2.json');
     test.deepEqual(actual, expected, 'Task should pass and modify the file permissions of all files that match.');
     
-    var rawMode = require('fs').statSync('tmp/custom_options_file.js').mode;
+    var rawMode = require('fs').statSync('tmp/custom_options_file_symbolic_2.js').mode;
     var numericMode = helpers.permsFromMode(rawMode);
     
     var actualPerms = '' + numericMode;
@@ -134,7 +134,7 @@ exports.chmod = {
     var expected = grunt.file.readJSON('test/expected/custom_options_file_symbolic_3.json');
     test.deepEqual(actual, expected, 'Task should pass and modify the file permissions of all files that match.');
     
-    var rawMode = require('fs').statSync('tmp/custom_options_file.js').mode;
+    var rawMode = require('fs').statSync('tmp/custom_options_file_symbolic_3.js').mode;
     var numericMode = helpers.permsFromMode(rawMode);
     
     var actualPerms = '' + numericMode;
@@ -151,7 +151,7 @@ exports.chmod = {
     var expected = grunt.file.readJSON('test/expected/custom_options_file_symbolic_4.json');
     test.deepEqual(actual, expected, 'Task should pass and modify the file permissions of all files that match.');
     
-    var rawMode = require('fs').statSync('tmp/custom_options_file.js').mode;
+    var rawMode = require('fs').statSync('tmp/custom_options_file_symbolic_4.js').mode;
     var numericMode = helpers.permsFromMode(rawMode);
     
     var actualPerms = '' + numericMode;

--- a/test/expected/custom_options_file_symbolic_1.json
+++ b/test/expected/custom_options_file_symbolic_1.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "chmod.success",
+    "args": []
+  }
+]

--- a/test/expected/custom_options_file_symbolic_2.json
+++ b/test/expected/custom_options_file_symbolic_2.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "chmod.success",
+    "args": []
+  }
+]

--- a/test/expected/custom_options_file_symbolic_3.json
+++ b/test/expected/custom_options_file_symbolic_3.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "chmod.success",
+    "args": []
+  }
+]

--- a/test/expected/custom_options_file_symbolic_4.json
+++ b/test/expected/custom_options_file_symbolic_4.json
@@ -1,0 +1,6 @@
+[
+  {
+    "name": "chmod.success",
+    "args": []
+  }
+]


### PR DESCRIPTION
Note that a bug in shelljs prevents you from reliably using some multi-symbolic strings like 'a-rwx,u+rw'. I have filed a separate PR which fixes that issue. The tests given here work around that issue by doing a manual fs.chmodSync() in the test preparation, so that we do not have to reset the permissions to a known value within the chmod task, we can just set the permissions we'd like. 

Feel free to target either rezonant/shelljs#feat-multisymbolic or rezonant/shelljs#master if you do not wish to wait for adoption in shelljs mainline.

This branch builds upon my previous PR introducing tests for the new symbolic chmods.
No changes other than the fs.chmodSync() -> shelljs.chmod() change were required for the tests to pass.